### PR TITLE
number 모듈을 단어변환필터에 추가

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -38,7 +38,7 @@
 //! ```
 
 use crate::hangeul::{is_hangeul, split_phonemes};
-use crate::number::{is_digits, change_nun_to_hangeul};
+use crate::number::{is_digits, change_num_to_hangeul};
 
 // ## 종성만 찾아서 도출해주는 함수
 // 이 함수는 특정 글자의 종성만 도출합니다.
@@ -88,7 +88,7 @@ pub fn filter_only_significant(word: &str) -> Vec<char> {
            numbers.push(c);
         }
         if !is_digits(c) || (i == word_len-1) {
-            let num = change_nun_to_hangeul(&numbers);
+            let num = change_num_to_hangeul(&numbers);
             let mut arr_num = num.chars().collect();
             output.append(&mut arr_num);
         }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -38,7 +38,7 @@
 //! ```
 
 use crate::hangeul::{is_hangeul, split_phonemes};
-use crate::number::{is_digits, change_int_char};
+use crate::number::{is_digits, change_nun_to_hangeul};
 
 // ## 종성만 찾아서 도출해주는 함수
 // 이 함수는 특정 글자의 종성만 도출합니다.
@@ -66,9 +66,11 @@ pub fn find_last_letter(word: &str) -> char {
 
 /// ##단어에서 불필요한 요소 제거하는 함수
 pub fn filter_only_significant(word: &str) -> Vec<char> {
+    let word_len = word.chars().count();
     let mut output: Vec<char> = Vec::new();
+    let mut numbers = String::new();
     let mut bracket: bool = false;
-    for c in word.chars() {
+    for (i, c) in word.chars().enumerate() {
         //괄호 있는지 확인
         if c == '(' {
             bracket = true;
@@ -80,9 +82,15 @@ pub fn filter_only_significant(word: &str) -> Vec<char> {
             continue;
         } else if is_hangeul(c) {
             output.push(c);
-        } else if is_digits(c) {
-            let num = change_int_char(c);
-            output.push(num);
+        }
+        //숫자라면 모아서 변형 후 아웃풋에 추가
+        if is_digits(c) {
+           numbers.push(c);
+        }
+        if !is_digits(c) || (i == word_len-1) {
+            let num = change_nun_to_hangeul(&numbers);
+            let mut arr_num = num.chars().collect();
+            output.append(&mut arr_num);
         }
     }
     return output;
@@ -98,5 +106,10 @@ mod tests {
         let temp = "넥슨(코리아)";
         let result = vec!['넥', '슨'];
         assert_eq!(result, filter_only_significant(temp));
+
+        let temp = "비타500";
+        let result = vec!['비','타','오','백'];
+        assert_eq!(result, filter_only_significant(temp));
+
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,8 +23,8 @@ pub fn guess_final(word: &str) -> char {
 }
 
 // number 모듈
-pub fn change_nun_to_hangeul(word: &str) -> String {
-    number::change_nun_to_hangeul(word)
+pub fn change_num_to_hangeul(word: &str) -> String {
+    number::change_num_to_hangeul(word)
 }
 
 pub fn change_int_char(num: char) -> char {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,10 @@
 use library::postfix;
+use library::find_last_letter;
 
 fn main() {
     // 테스트
-    println!("{:?}", postfix("   ", "은"));
+    println!("{:?}", postfix("테스트", "은"));
     println!("{:?}", postfix("나뭇가지(만렙)", "이다"));
     println!("{:?}", postfix("집", "는"));
+    println!("{:?}", find_last_letter("비타500"));
 }

--- a/src/number.rs
+++ b/src/number.rs
@@ -32,7 +32,7 @@ pub fn change_int_char(num: char) -> char {
 
 /// ## 숫자를 한글 발음으로 바꿔주는 함수
 /// 입력된 숫자를 한글 발음으로 바꿔줍니다.
-pub fn change_nun_to_hangeul(num: &str) -> String {
+pub fn change_num_to_hangeul(num: &str) -> String {
     // 입력된 숫자 문자열을 뒤에서부터 읽기 위해서 입력된 숫자 문자열을 뒤집는다.
     let char_vec: Vec<char> = num.chars().rev().collect();
     let mut temp_result: Vec<char> = Vec::new();

--- a/src/number.rs
+++ b/src/number.rs
@@ -19,7 +19,6 @@ const EXPS: [char; 12] = [
 ];
 
 /// ## 해당 문자가 숫자인지 아닌지 확인하는 함수
-/// 
 /// 입력된 문자가 숫자이면 `true`, 아니면 `false`를 반환합니다.
 pub fn is_digits(num: char) -> bool {
     return '0' <= num && num <= '9';
@@ -37,7 +36,7 @@ pub fn change_nun_to_hangeul(num: &str) -> String {
     // 입력된 숫자 문자열을 뒤에서부터 읽기 위해서 입력된 숫자 문자열을 뒤집는다.
     let char_vec: Vec<char> = num.chars().rev().collect();
     let mut temp_result: Vec<char> = Vec::new();
-
+    
     let mut temp_exps = 0;
 
     for (i, x) in char_vec.iter().enumerate() {

--- a/tests/number.rs
+++ b/tests/number.rs
@@ -36,6 +36,10 @@ fn _change_int_char() {
 
 #[test]
 fn _change_nun_to_hangeul() {
+    let test = "10";
+    let result = "십";
+    assert_eq!(result, change_nun_to_hangeul(test));
+
     let test = "10000";
     let result = "만";
     assert_eq!(result, change_nun_to_hangeul(test));


### PR DESCRIPTION
- 새로 작성된 number 모듈을 단어변환 시 사용하기 위해서 filter_only_significant()의 숫자 부분의 코드를 변경합니다.
예시)
```
filter_only_significant("비타500")
> ['비','타','오','백']
```
